### PR TITLE
Change tproa.net link

### DIFF
--- a/taxonomy-of-snarky-pursuits.md
+++ b/taxonomy-of-snarky-pursuits.md
@@ -36,5 +36,5 @@ Some combiners:
 * Professor of
 
 
-If you really want to limber your psyche up for this sort of thing, just read through [the list of titles and styles at the end of this page](https://web.tproa.net/)
+If you really want to limber your psyche up for this sort of thing, just read through [the list of titles and styles at this page](https://web.tproa.net/official.sig.txt)
 


### PR DESCRIPTION
Point to current and complete list of TPROA official titles, instead
of historical copy.
